### PR TITLE
Rm6627 adapt Linux for Emcraft project build scheme

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -300,7 +300,12 @@ INSTALL_TARGETS	= zinstall uinstall install
 
 PHONY += bzImage $(BOOT_TARGETS) $(INSTALL_TARGETS)
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+bootpImage uImage: Image
+else
 bootpImage uImage: zImage
+endif
+
 zImage: Image
 
 $(BOOT_TARGETS): vmlinux

--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -63,8 +63,14 @@ $(obj)/Image: vmlinux FORCE
 $(obj)/compressed/vmlinux: $(obj)/Image FORCE
 	$(Q)$(MAKE) $(build)=$(obj)/compressed $@
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+$(obj)/zImage: FORCE
+	@$(kecho) 'Kernel configured for no compression (CONFIG_COMPRESS_NONE=y)'
+	@false
+else
 $(obj)/zImage:	$(obj)/compressed/vmlinux FORCE
 	$(call if_changed,objcopy)
+endif
 
 endif
 
@@ -86,9 +92,14 @@ if [ $(words $(UIMAGE_LOADADDR)) -ne 1 ]; then \
 	false; \
 fi
 
+ifeq ($(CONFIG_KERNEL_COMPRESS_NONE),y)
+$(obj)/uImage:	$(obj)/Image FORCE
+	$(call if_changed,uimage)
+else
 $(obj)/uImage:	$(obj)/zImage FORCE
 	@$(check_for_multiple_loadaddr)
 	$(call if_changed,uimage)
+endif
 
 $(obj)/bootp/bootp: $(obj)/zImage initrd FORCE
 	$(Q)$(MAKE) $(build)=$(obj)/bootp $@

--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -84,6 +84,20 @@ else
   endif
 endif
 
+ifeq ($(UIMAGE_LOADADDR),)
+  UIMAGE_LOADADDR=$(shell /bin/bash -c 'printf "0x%08x" \
+					$$[$(CONFIG_DRAM_BASE) + 0x008000]')
+endif
+
+ifeq ($(UIMAGE_ENTRYADDR),)
+  ifeq ($(CONFIG_THUMB2_KERNEL),y)
+    # Set bit 0 to 1 so that "mov pc, rx" switches to Thumb-2 mode
+    UIMAGE_ENTRYADDR?=$(shell echo $(UIMAGE_LOADADDR) | sed -e "s/.$$/1/")
+  else
+    UIMAGE_ENTRYADDR?=$(UIMAGE_LOADADDR)
+  endif
+endif
+
 check_for_multiple_loadaddr = \
 if [ $(words $(UIMAGE_LOADADDR)) -ne 1 ]; then \
 	echo 'multiple (or no) load addresses: $(UIMAGE_LOADADDR)'; \

--- a/arch/arm/kernel/vmlinux.lds.S.good
+++ b/arch/arm/kernel/vmlinux.lds.S.good
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* ld script to make ARM Linux kernel
+ * taken from the i386 version by Russell King
+ * Written by Martin Mares <mj@atrey.karlin.mff.cuni.cz>
+ */
+
+#ifdef CONFIG_XIP_KERNEL
+#include "vmlinux-xip.lds.S"
+#else
+
+#include <linux/pgtable.h>
+#include <asm/vmlinux.lds.h>
+#include <asm/cache.h>
+#include <asm/thread_info.h>
+#include <asm/memory.h>
+#include <asm/mpu.h>
+#include <asm/page.h>
+
+OUTPUT_ARCH(arm)
+ENTRY(stext)
+
+#ifndef __ARMEB__
+jiffies = jiffies_64;
+#else
+jiffies = jiffies_64 + 4;
+#endif
+
+SECTIONS
+{
+	/*
+	 * XXX: The linker does not define how output sections are
+	 * assigned to input sections when there are multiple statements
+	 * matching the same input section name.  There is no documented
+	 * order of matching.
+	 *
+	 * unwind exit sections must be discarded before the rest of the
+	 * unwind sections get included.
+	 */
+	/DISCARD/ : {
+		ARM_DISCARD
+#ifndef CONFIG_SMP_ON_UP
+		*(.alt.smp.init)
+#endif
+#ifndef CONFIG_ARM_UNWIND
+		*(.ARM.exidx) *(.ARM.exidx.*)
+		*(.ARM.extab) *(.ARM.extab.*)
+#endif
+	}
+
+	. = KERNEL_OFFSET + TEXT_OFFSET;
+	.head.text : {
+		_text = .;
+		HEAD_TEXT
+	}
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#endif
+
+#ifdef CONFIG_ARM_MPU
+	. = ALIGN(PMSAv8_MINALIGN);
+#endif
+	.text : {			/* Real text segment		*/
+		_stext = .;		/* Text and read-only data	*/
+		ARM_TEXT
+	}
+
+#ifdef CONFIG_DEBUG_ALIGN_RODATA
+	. = ALIGN(1<<SECTION_SHIFT);
+#endif
+	_etext = .;			/* End of text section */
+
+	RO_DATA(PAGE_SIZE)
+
+	. = ALIGN(4);
+	__ex_table : AT(ADDR(__ex_table) - LOAD_OFFSET) {
+		__start___ex_table = .;
+		ARM_MMU_KEEP(*(__ex_table))
+		__stop___ex_table = .;
+	}
+
+#ifdef CONFIG_ARM_UNWIND
+	ARM_UNWIND_SECTIONS
+#endif
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#else
+	. = ALIGN(PAGE_SIZE);
+#endif
+	__init_begin = .;
+
+	ARM_VECTORS
+	INIT_TEXT_SECTION(8)
+	.exit.text : {
+		ARM_EXIT_KEEP(EXIT_TEXT)
+	}
+	.init.proc.info : {
+		ARM_CPU_DISCARD(PROC_INFO)
+	}
+	.init.arch.info : {
+		__arch_info_begin = .;
+		*(.arch.info.init)
+		__arch_info_end = .;
+	}
+	.init.tagtable : {
+		__tagtable_begin = .;
+		*(.taglist.init)
+		__tagtable_end = .;
+	}
+#ifdef CONFIG_SMP_ON_UP
+	.init.smpalt : {
+		__smpalt_begin = .;
+		*(.alt.smp.init)
+		__smpalt_end = .;
+	}
+#endif
+	.init.pv_table : {
+		__pv_table_begin = .;
+		*(.pv_table)
+		__pv_table_end = .;
+	}
+
+	INIT_DATA_SECTION(16)
+
+	.exit.data : {
+		ARM_EXIT_KEEP(EXIT_DATA)
+	}
+
+#ifdef CONFIG_SMP
+	PERCPU_SECTION(L1_CACHE_BYTES)
+#endif
+
+#ifdef CONFIG_HAVE_TCM
+	ARM_TCM
+#endif
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+	. = ALIGN(1<<SECTION_SHIFT);
+#else
+	. = ALIGN(THREAD_SIZE);
+#endif
+	__init_end = .;
+
+	_sdata = .;
+	RW_DATA(L1_CACHE_BYTES, PAGE_SIZE, THREAD_SIZE)
+	_edata = .;
+
+	BSS_SECTION(0, 0, 0)
+#ifdef CONFIG_ARM_MPU
+	. = ALIGN(PMSAv8_MINALIGN);
+#endif
+	_end = .;
+
+	STABS_DEBUG
+	DWARF_DEBUG
+	ARM_DETAILS
+
+	ARM_ASSERTS
+}
+
+#ifdef CONFIG_STRICT_KERNEL_RWX
+/*
+ * Without CONFIG_DEBUG_ALIGN_RODATA, __start_rodata_section_aligned will
+ * be the first section-aligned location after __start_rodata. Otherwise,
+ * it will be equal to __start_rodata.
+ */
+__start_rodata_section_aligned = ALIGN(__start_rodata, 1 << SECTION_SHIFT);
+#endif
+
+/*
+ * These must never be empty
+ * If you have to comment these two assert statements out, your
+ * binutils is too old (for other reasons as well)
+ */
+ASSERT((__proc_info_end - __proc_info_begin), "missing CPU support")
+ASSERT((__arch_info_end - __arch_info_begin), "no machine record defined")
+
+#endif /* CONFIG_XIP_KERNEL */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -300,6 +300,11 @@ config KERNEL_LZO
 	  size is about 10% bigger than gzip; however its speed
 	  (both compression and decompression) is the fastest.
 
+config KERNEL_COMPRESS_NONE
+	bool "NONE"
+	help
+	  No compression of the kernel image. Fastest decompression time.
+
 config KERNEL_LZ4
 	bool "LZ4"
 	depends on HAVE_KERNEL_LZ4

--- a/initramfs-list-min.stub
+++ b/initramfs-list-min.stub
@@ -1,0 +1,6 @@
+# This is a stub initramfs.
+# We need it in order to build a stub initramfs, so
+# as to complete a kernel build successfully, before
+# we can run build and installation of kernel modules.
+
+dir /dev 0755 0 0

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -425,13 +425,14 @@ UIMAGE_TYPE ?= kernel
 UIMAGE_LOADADDR ?= arch_must_set_this
 UIMAGE_ENTRYADDR ?= $(UIMAGE_LOADADDR)
 UIMAGE_NAME ?= 'Linux-$(KERNELRELEASE)'
+UIMAGE_IN ?= $<
 
 quiet_cmd_uimage = UIMAGE  $@
       cmd_uimage = $(BASH) $(MKIMAGE) -A $(UIMAGE_ARCH) -O linux \
 			-C $(UIMAGE_COMPRESSION) $(UIMAGE_OPTS-y) \
 			-T $(UIMAGE_TYPE) \
 			-a $(UIMAGE_LOADADDR) -e $(UIMAGE_ENTRYADDR) \
-			-n $(UIMAGE_NAME) -d $< $@
+			-n $(UIMAGE_NAME) -d $(UIMAGE_IN) $@
 
 # XZ
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Same PR as was made to linux-stm repo to prepare linux 5.15 for Emcraft 'project' build procedure (refer to https://github.com/EmcraftSystems/linux-stm/pull/1)