### PR TITLE
RM 6627. imxrt: clocks: Add CLK_IS_CRITICAL flag to the SEMC clock, to

### DIFF
--- a/drivers/clk/imx/clk-imxrt1020.c
+++ b/drivers/clk/imx/clk-imxrt1020.c
@@ -109,9 +109,9 @@ static int imxrt1020_clk_probe(struct platform_device *pdev)
 	hws[IMXRT1020_CLK_SEMC_ALT_SEL] = imx_clk_hw_mux("semc_alt_sel",
 		base + 0x14, 7, 1,
 		semc_alt_sels, ARRAY_SIZE(semc_alt_sels));
-	hws[IMXRT1020_CLK_SEMC_SEL] = imx_clk_hw_mux("semc_sel",
+	hws[IMXRT1020_CLK_SEMC_SEL] = imx_clk_hw_mux_flags("semc_sel",
 		base + 0x14, 6, 1,
-		semc_sels, ARRAY_SIZE(semc_sels));
+		semc_sels, ARRAY_SIZE(semc_sels), CLK_IS_CRITICAL);
 
 	hws[IMXRT1020_CLK_AHB_PODF] = imx_clk_hw_divider("ahb", "periph_sel",
 		base + 0x14, 10, 3);


### PR DESCRIPTION
Add CLK_IS_CRITICAL flag to the SEMC clock, to prevent disabling it by other drivers whose clocks also depend on pll2_sys. SEMC clock is currently configured by U-Boot and Linux drivers do not manage it at all, so we must keep it always on.

Unit test:

Configure USDHC clocks in DTS to use the common IMXRT1020 clock driver, make sure the target board is bootable: both USDHC and SEMC clocks are children of PLL2_SYS, so Linux could disable PLL2_SYS when disable the USDHC clock when unused, but this shall not happen if SEMC clock has the CRITICAL flag:

```
		esdhc0: esdhc@402c0000 {
			compatible = "fsl,imx6sl-usdhc";
			reg = <0x402c0000 0x1000>;
			interrupts = <110>;
			clocks = <&clks IMXRT1020_CLK_USDHC1>,
				 <&clks IMXRT1020_CLK_USDHC1>,
				 <&clks IMXRT1020_CLK_USDHC1>;
			clock-names = "ipg", "ahb", "per";
		};
```
