### PR TITLE
RM 6734 Configure imxrt1170 enet1

### DIFF
--- a/arch/arm/boot/dts/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/imxrt1170.dtsi
@@ -33,6 +33,24 @@
 		};
 	};
 
+	aliases {
+		gpio0 = &gpio1;
+		gpio1 = &gpio2;
+		gpio2 = &gpio3;
+		gpio3 = &gpio4;
+		gpio4 = &gpio5;
+		gpio5 = &gpio6;
+		gpio6 = &gpio7;
+		gpio7 = &gpio8;
+		gpio8 = &gpio9;
+		gpio9 = &gpio10;
+		gpio10 = &gpio11;
+		gpio11 = &gpio12;
+		gpio12 = &gpio13;
+		mmc0 = &usdhc1;
+		serial0 = &lpuart1;
+	};
+
 	soc {
 		iomuxc: iomuxc@400e8000 {
 			compatible = "fsl,imxrt1170-iomuxc";
@@ -104,6 +122,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 0 32>;
 		};
 
 		gpio2: gpio@40130000 {
@@ -115,6 +134,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 32 32>;
 		};
 
 		gpio3: gpio@40134000 {
@@ -126,6 +146,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 64 32>;
 		};
 
 		gpio4: gpio@40138000 {
@@ -137,6 +158,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 96 32>;
 		};
 
 		gpio5: gpio@4013c000 {
@@ -148,6 +170,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 128 32>;
 		};
 
 		gpio6: gpio@40140000 {
@@ -159,6 +182,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 160 32>;
 		};
 
 		gpio7: gpio@40c5c000 {
@@ -170,6 +194,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 192 32>;
 		};
 
 		gpio8: gpio@40c60000 {
@@ -181,6 +206,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 224 32>;
 		};
 
 		gpio9: gpio@40c64000 {
@@ -192,6 +218,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 256 32>;
 		};
 
 		gpio10: gpio@40c68000 {
@@ -203,6 +230,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 288 32>;
 		};
 
 		gpio11: gpio@40c6c000 {
@@ -214,6 +242,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc 0 320 32>;
 		};
 
 		gpio12: gpio@40c70000 {
@@ -225,6 +254,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc_lpsr 0 0 32>;
 		};
 
 		gpio13: gpio@40ca0000 {
@@ -236,6 +266,7 @@
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
+			gpio-ranges = <&iomuxc_snvs 0 0 32>;
 		};
 
 		gpt1: gpt1@400ec000 {

--- a/arch/arm/boot/dts/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/imxrt1170.dtsi
@@ -58,6 +58,11 @@
 			fsl,mux_mask = <0xf>;
 		};
 
+		gpr: iomuxc-gpr@400e4000 {
+			compatible = "fsl,imxrt1170-iomuxc-gpr", "syscon";
+			reg = <0x400e4000 0x4000>;
+		};
+
 		iomuxc_lpsr: iomuxc_lpsr@40c08000 {
 			compatible = "fsl,imxrt1170-lpsr-iomuxc";
 			reg = <0x40c08000 0x4000>;

--- a/arch/arm/boot/dts/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/imxrt1170.dtsi
@@ -105,11 +105,12 @@
 		};
 
 		fec1: ethernet@40424000 {
-			compatible = "fsl,imxrt1xxx-fec";
+			compatible = "fsl,mvf600-fec";
 			reg = <0x40424000 0x4000>;
+			interrupts = <137>;
 
-			fsl,num-tx-queues=<3>;
-			fsl,num-rx-queues=<3>;
+			fsl,num-tx-queues=<1>;
+			fsl,num-rx-queues=<1>;
 			status = "disabled";
                 };
 


### PR DESCRIPTION
Unit test:

The network operates correctly through the ENET1 interface  of IMXRT1170-EVK board.