### PR TITLE
RM 6843. Add support for the ENET Fec controller on i.MXRT1050 targtes

### DIFF
--- a/arch/arm/boot/dts/imxrt1050.dtsi
+++ b/arch/arm/boot/dts/imxrt1050.dtsi
@@ -2,6 +2,8 @@
 /*
  * Copyright (C) 2019
  * Author(s): Giulio Benetti <giulio.benetti@benettiengineering.com>
+ * Copyright (C) 2023 Emcraft Systems
+ * Author(s): Vladimir Skvortsov <vskvortsov@emcraft.com>
  */
 
 #include "armv7-m.dtsi"
@@ -41,6 +43,11 @@
 			compatible = "fsl,imxrt1050-iomuxc";
 			reg = <0x401f8000 0x4000>;
 			fsl,mux_mask = <0x7>;
+		};
+
+		gpr: iomuxc-gpr@400ac000 {
+			compatible = "fsl,imxrt1050-iomuxc-gpr", "syscon";
+			reg = <0x400ac000 0x4000>;
 		};
 
 		anatop: anatop@400d8000 {
@@ -155,6 +162,16 @@
 			interrupts = <100>;
 			clocks = <&osc3M>;
 			clock-names = "per";
+		};
+
+		fec: ethernet@402d8000 {
+			compatible = "fsl,imxrt1050-fec", "fsl,mvf600-fec";
+			reg = <0x402d8000 0x1000>;
+			interrupts = <114>;
+			clocks = <&clks IMXRT1050_CLK_ENET>,
+				 <&clks IMXRT1050_CLK_AHB_PODF>;
+			clock-names = "ipg", "ahb";
+			status = "disabled";
 		};
 	};
 };

--- a/include/dt-bindings/clock/imxrt1050-clock.h
+++ b/include/dt-bindings/clock/imxrt1050-clock.h
@@ -2,6 +2,8 @@
 /*
  * Copyright(C) 2019
  * Author(s): Giulio Benetti <giulio.benetti@benettiengineering.com>
+ * Copyright (C) 2023 Emcraft Systems
+ * Author(s): Vladimir Skvortsov <vskvortsov@emcraft.com>
  */
 
 #ifndef __DT_BINDINGS_CLOCK_IMXRT1050_H
@@ -67,6 +69,10 @@
 #define IMXRT1050_CLK_PER_PDOF			58
 #define IMXRT1050_CLK_DMA			59
 #define IMXRT1050_CLK_DMA_MUX			60
-#define IMXRT1050_CLK_END			61
+#define IMXRT1050_CLK_PLL6			61
+#define IMXRT1050_CLK_PLL6_BYPASS		62
+#define IMXRT1050_CLK_ENET_REF			63
+#define IMXRT1050_CLK_ENET			64
+#define IMXRT1050_CLK_END			65
 
 #endif /* __DT_BINDINGS_CLOCK_IMXRT1050_H */


### PR DESCRIPTION
Unit test:

Successfully boot up to Linux shell. Configure eth0 iface and ping an external host.