### PR TITLE
RM-6829: Add a possibility to enable broadcast address for Micrel phy driver.

### DIFF
--- a/drivers/net/phy/micrel.c
+++ b/drivers/net/phy/micrel.c
@@ -551,6 +551,13 @@ static int kszphy_config_reset(struct phy_device *phydev)
 	return 0;
 }
 
+static int kszphy_is_broadcast_address_allowed(struct phy_device *phydev)
+{
+	struct device_node *of_node = phydev->mdio.dev.of_node;
+
+	return of_property_read_bool(of_node, "micrel,kszphy-allow-broadcast-address");
+}
+
 static int kszphy_config_init(struct phy_device *phydev)
 {
 	struct kszphy_priv *priv = phydev->priv;
@@ -561,7 +568,7 @@ static int kszphy_config_init(struct phy_device *phydev)
 
 	type = priv->type;
 
-	if (type && type->has_broadcast_disable)
+	if (type && type->has_broadcast_disable && !kszphy_is_broadcast_address_allowed(phydev))
 		kszphy_broadcast_disable(phydev);
 
 	if (type && type->has_nand_tree_disable)


### PR DESCRIPTION
**Unit test**

1. build the rootfs project with this change applied
2. install the rootfs.uImage in the SD card
3. boot the board
4. check ethernet
mmcblk0: p1 p2
Micrel KSZ8081 or KSZ8091 40424000.ethernet-1:00: attached PHY driver (mii_bus:phy_addr=40424000.ethernet-1:00, irq=POLL)
fec 40424000.ethernet eth0: Link is Up - 100Mbps/Full - flow control off
/ # ping -c 3 google.com
PING google.com (108.177.14.139): 56 data bytes
64 bytes from 108.177.14.139: seq=0 ttl=102 time=30.284 ms
64 bytes from 108.177.14.139: seq=1 ttl=102 time=29.838 ms
64 bytes from 108.177.14.139: seq=2 ttl=102 time=29.849 ms

--- google.com ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 29.838/29.990/30.284 ms
/ #
5. unplug the ethernet cable
fec 40424000.ethernet eth0: Link is Down
6. plug the ethernet cable and check ethernet
fec 40424000.ethernet eth0: Link is Up - 100Mbps/Full - flow control off

/ # ping -c 3 google.com
PING google.com (173.194.73.100): 56 data bytes
64 bytes from 173.194.73.100: seq=0 ttl=105 time=20.854 ms
64 bytes from 173.194.73.100: seq=1 ttl=105 time=20.214 ms
64 bytes from 173.194.73.100: seq=2 ttl=105 time=19.470 ms

--- google.com ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 19.470/20.179/20.854 ms
/ # 