### PR TITLE
RM-6933: arm: imxrt: Add invocation of traps_v7m_init()

### DIFF
--- a/arch/arm/kernel/traps-v7m.c
+++ b/arch/arm/kernel/traps-v7m.c
@@ -123,7 +123,7 @@ void traps_v7m_init(void){
 	writel(readl(&NVIC->system_handler_csr) | USGFAULTENA | BUSFAULTENA,
 			&NVIC->system_handler_csr);
 	writel(
-#ifndef CONFIG_ARM_V7M_NO_UNALIGN_TRP
+#if !defined(CONFIG_ARM_V7M_NO_UNALIGN_TRP) && 0
 		UNALIGN_TRP |
 #endif
 		DIV_0_TRP | readl(&NVIC->config_control),

--- a/arch/arm/kernel/traps-v7m.h
+++ b/arch/arm/kernel/traps-v7m.h
@@ -1,0 +1,27 @@
+/*
+ * linux/arch/arm/kernel/traps-v7m.h
+ *
+ * Copyright (C) 2011 Dmitry Cherukhin, Emcraft Systems
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __ARM_KERNEL_TRAPS_V7M_H
+#define __ARM_KERNEL_TRAPS_V7M_H
+
+void traps_v7m_init(void);
+
+#endif
+

--- a/arch/arm/kernel/traps.c
+++ b/arch/arm/kernel/traps.c
@@ -40,6 +40,9 @@
 #include <asm/system_misc.h>
 #include <asm/opcodes.h>
 
+#if defined(CONFIG_CPU_V7M)
+#include "traps-v7m.h"
+#endif
 
 static const char *handler[]= {
 	"prefetch abort",
@@ -892,6 +895,9 @@ void __init early_trap_init(void *vectors_base)
 	 * memory area. The address is configurable and so a table in the kernel
 	 * image can be used.
 	 */
+
+	/* Initialize Bus fault and Usage fault exceptions */
+	traps_v7m_init();
 }
 #endif
 


### PR DESCRIPTION
**Unit test**
1. Boot the imxrt1170 board by the roots project with these changes applied
2. Check that the system is booted successfully and operates as expected
3. Run the following test program and check the result:
#include <stdio.h>
void main(void)
{
        int a = 1000;
        int b = 0;

        printf("Result = %d\n", a / b);
}
- On imxrt1170 release 3.0.4:
/ # /tmp/t
Result = 0
/ #
- On imxrt1170 with these changes applied:
/ # /tmp/t


t: fault at 0x8212173e [pc=0x8212173e, sp=0x81a3fd30]
Divide By 0

Segmentation fault

