### PR TITLE
FIX VFP issues for arm-v7m

### DIFF
--- a/arch/arm/kernel/vfp-m.c
+++ b/arch/arm/kernel/vfp-m.c
@@ -106,13 +106,19 @@ static int vfpm_notifier(struct notifier_block *self, unsigned long cmd,
 
 	switch (cmd) {
 	case THREAD_NOTIFY_FLUSH:
-		memset(&thread->vfpstate, 0, sizeof(thread->vfpstate));
-		thread->vfpstate.hard.used = 0;
-		/* fallthrough */
+		if (thread->vfpstate.hard.used != 0) {
+			memset(&thread->vfpstate, 0, sizeof(thread->vfpstate));
+			thread->vfpstate.hard.used = 0;
+			vfpm_disable_access();
+			vfpm_last_thread = NULL;
+		}
+		break;
 
 	case THREAD_NOTIFY_EXIT:
-		vfpm_disable_access();
-		vfpm_last_thread = NULL;
+		if (thread->vfpstate.hard.used != 0) {
+			vfpm_disable_access();
+			vfpm_last_thread = NULL;
+		}
 		break;
 
 	case THREAD_NOTIFY_SWITCH:


### PR DESCRIPTION
Merged PR for linx 5.15 to 6.1 branch

RM-6943: ARM: arm-v7m VFP: Fix issues in VFP code which lead to losing the floating point context when switching tasks.


Unit test:

make sure there is no "unresolved symbol" messages when booting IMXRT1170-EVK board.