### PR TITLE
Fix edma issues for the i.MXRT1170 target

### DIFF
--- a/arch/arm/boot/dts/imxrt1050.dtsi
+++ b/arch/arm/boot/dts/imxrt1050.dtsi
@@ -71,7 +71,7 @@
 
 		edma1: dma-controller@400e8000 {
 			#dma-cells = <2>;
-			compatible = "fsl,imx7ulp-edma";
+			compatible = "fsl,imxrt1050-edma";
 			reg = <0x400e8000 0x4000>,
 				<0x400ec000 0x4000>;
 			dma-channels = <32>;

--- a/arch/arm/boot/dts/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/imxrt1170.dtsi
@@ -106,7 +106,7 @@
 
 		edma0: dma-controller@40080000 {
 			#dma-cells = <2>;
-			compatible = "fsl,imx7ulp-edma";
+			compatible = "fsl,imxrt1170-edma";
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			dma-channels = <32>;

--- a/drivers/dma/fsl-edma-common.c
+++ b/drivers/dma/fsl-edma-common.c
@@ -120,7 +120,10 @@ void fsl_edma_chan_mux(struct fsl_edma_chan *fsl_chan,
 		ch_off += endian_diff[ch_off % 4];
 
 	muxaddr = fsl_chan->edma->muxbase[ch / chans_per_mux];
-	slot = EDMAMUX_CHCFG_SOURCE(slot);
+	if (fsl_chan->edma->drvdata->mux_slot_mask)
+		slot &= fsl_chan->edma->drvdata->mux_slot_mask;
+	else
+		slot = EDMAMUX_CHCFG_SOURCE(slot);
 
 	if (fsl_chan->edma->drvdata->version == v3)
 		mux_configure32(fsl_chan, muxaddr, ch_off, slot, enable);

--- a/drivers/dma/fsl-edma-common.h
+++ b/drivers/dma/fsl-edma-common.h
@@ -153,6 +153,7 @@ struct fsl_edma_drvdata {
 	u32			dmamuxs;
 	bool			has_dmaclk;
 	bool			mux_swap;
+	u32			mux_slot_mask;
 	int			(*setup_irq)(struct platform_device *pdev,
 					     struct fsl_edma_engine *fsl_edma);
 	u8			txirq_count;

--- a/drivers/dma/fsl-edma.c
+++ b/drivers/dma/fsl-edma.c
@@ -309,6 +309,15 @@ static struct fsl_edma_drvdata imxrt1050_data = {
 	.mux_slot_mask = 0x7f,
 };
 
+static struct fsl_edma_drvdata imxrt1170_data = {
+	.version = v3,
+	.dmamuxs = 1,
+	.has_dmaclk = true,
+	.setup_irq = fsl_edma2_irq_init,
+	.txirq_count = 16,
+	.mux_slot_mask = 0xff,
+};
+
 static struct fsl_edma_drvdata s32v234_data = {
 	.version = v1,
 	.dmamuxs = DMAMUX_NR,
@@ -322,6 +331,7 @@ static const struct of_device_id fsl_edma_dt_ids[] = {
 	{ .compatible = "fsl,ls1028a-edma", .data = &ls1028a_data},
 	{ .compatible = "fsl,imx7ulp-edma", .data = &imx7ulp_data},
 	{ .compatible = "fsl,imxrt1050-edma", .data = &imxrt1050_data},
+	{ .compatible = "fsl,imxrt1170-edma", .data = &imxrt1170_data},
 	{ .compatible = "fsl,s32v234-edma", .data = &s32v234_data},
 	{ /* sentinel */ }
 };

--- a/drivers/dma/fsl-edma.c
+++ b/drivers/dma/fsl-edma.c
@@ -300,6 +300,15 @@ static struct fsl_edma_drvdata imx7ulp_data = {
 	.txirq_count = 16,
 };
 
+static struct fsl_edma_drvdata imxrt1050_data = {
+	.version = v3,
+	.dmamuxs = 1,
+	.has_dmaclk = true,
+	.setup_irq = fsl_edma2_irq_init,
+	.txirq_count = 16,
+	.mux_slot_mask = 0x7f,
+};
+
 static struct fsl_edma_drvdata s32v234_data = {
 	.version = v1,
 	.dmamuxs = DMAMUX_NR,
@@ -312,6 +321,7 @@ static const struct of_device_id fsl_edma_dt_ids[] = {
 	{ .compatible = "fsl,vf610-edma", .data = &vf610_data},
 	{ .compatible = "fsl,ls1028a-edma", .data = &ls1028a_data},
 	{ .compatible = "fsl,imx7ulp-edma", .data = &imx7ulp_data},
+	{ .compatible = "fsl,imxrt1050-edma", .data = &imxrt1050_data},
 	{ .compatible = "fsl,s32v234-edma", .data = &s32v234_data},
 	{ /* sentinel */ }
 };


### PR DESCRIPTION
This PR cherry-picks the commit from the emcraft-5.15 branch which fixed the error in the fsl-edma driver with the incorrect mask applied to the slot number when configure the mux source.

The problem is also actual for the IMXRT1170 target. But eDMA MUX on IMXRT1170 has more possible sources than is available on IMXRT1050. So this PR adds separate drvdata for IMXRT1170 with mux_slot_mask = 0xff.


Unit test:

Verify that DMA transfers are functional on the IMXRT1170-EVK board using the LPSPI1 controller configured with DMA and SPI Flash. 