### PR TITLE
RM 7016 support 16 bits framebuffer in imxrt1170

### DIFF
--- a/drivers/video/fbdev/mxsfb.c
+++ b/drivers/video/fbdev/mxsfb.c
@@ -1501,6 +1501,7 @@ static int mxsfb_dispdrv_init(struct platform_device *pdev,
 
 	memset(&setting, 0x0, sizeof(setting));
 	setting.fbi = fbi;
+	setting.default_bpp = fbi->var.bits_per_pixel;
 	memcpy(disp_dev, host->disp_dev, strlen(host->disp_dev));
 	disp_dev[strlen(host->disp_dev)] = '\0';
 


### PR DESCRIPTION
This patch updates the mxsfb driver to pass the bits_per_pixel fb setting to the display driver. This will allow to use 16-bits framebuffers with 32-bits  mipi-dsi displays.

Unit-test:
 * use IMXRT117-EVK + RK055HDMIPI4MA0 LCD pannel
 * set ```bits-per-pixel = <16>``` in the display node in DTS
 * make sure ```lcdtest``` reports 720x1280, 16bpp for the framebuffer settings and draws its pattern correctly

