### PR TITLE
RM-7238: imxrt1050.dtsi: Adjust SPI nodes names in DTS to recommended in Linux

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imxrt1050.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imxrt1050.dtsi
@@ -350,22 +350,22 @@
 			status = "disabled";
 		};
 
-		lpspi1: lpspi@40394000 {
+		lpspi1: spi@40394000 {
 			/* TBD */
 			status = "disabled";
 		};
 
-		lpspi2: lpspi@40398000 {
+		lpspi2: spi@40398000 {
 			/* TBD */
 			status = "disabled";
 		};
 
-		lpspi3: lpspi@4039c000 {
+		lpspi3: spi@4039c000 {
 			/* TBD */
 			status = "disabled";
 		};
 
-		lpspi4: lpspi@403a0000 {
+		lpspi4: spi@403a0000 {
 			/* TBD */
 			status = "disabled";
 		};

--- a/arch/arm/boot/dts/nxp/imx/imxrt1050.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imxrt1050.dtsi
@@ -296,7 +296,7 @@
 			clocks = <&clks IMXRT1050_CLK_USBOH3>;
 		};
 
-		lpi2c1: lpci2c@403f0000 {
+		lpi2c1: i2c@403f0000 {
 			compatible = "fsl,imx7ulp-lpi2c";
 			reg = <0x403f0000 0x4000>;
 			interrupts = <28>;
@@ -307,7 +307,7 @@
 			status = "disabled";
 		};
 
-		lpi2c2: lpci2c@403f4000 {
+		lpi2c2: i2c@403f4000 {
 			compatible = "fsl,imx7ulp-lpi2c";
 			reg = <0x403f4000 0x4000>;
 			interrupts = <29>;
@@ -318,7 +318,7 @@
 			status = "disabled";
 		};
 
-		lpi2c3: lpci2c@403f8000 {
+		lpi2c3: i2c@403f8000 {
 			compatible = "fsl,imx7ulp-lpi2c";
 			reg = <0x403f8000 0x4000>;
 			interrupts = <30>;
@@ -329,7 +329,7 @@
 			status = "disabled";
 		};
 
-		lpi2c4: lpci2c@403fc000 {
+		lpi2c4: i2c@403fc000 {
 			compatible = "fsl,imx7ulp-lpi2c";
 			reg = <0x403fc000 0x4000>;
 			interrupts = <31>;


### PR DESCRIPTION
**Unit test**
Build the rootfs project and run rootfs.uImage on imxrt1050-evkb board.
Check that there are no any warning while building DTS.
**Unit test results**
Unit test performed and is a success