### PR TITLE
RM-7588: imxrt1170: pinctrl: dts: Fixed a typo in the compatible string

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imxrt1170.dtsi
@@ -83,7 +83,7 @@
 		};
 
 		iomuxc_snvs: iomuxc_snvs@40c94000 {
-			compatible = "fsl,imxrt1170-lpsr-iomuxc";
+			compatible = "fsl,imxrt1170-snvs-iomuxc";
 			reg = <0x40c94000 0x4000>;
 			fsl,mux_mask = <0x7>;
 		};


### PR DESCRIPTION
Due to a typo in the compatible string for the iomuxc_snvs group pins, the pin names are shown incorrectly in the debugfs:
```
/ # cat /sys/kernel/debug/pinctrl/40c94000.iomuxc_snvs/pinmux-pins
Pinmux settings per pin
Format: pin (name): mux_owner gpio_owner hog?
pin 0 (IMXRT1170_PAD_GPIO_LPSR_00): gpio-keys 40ca0000.gpio:384 function iomuxc_snvs group keysgrp
pin 1 (IMXRT1170_PAD_GPIO_LPSR_01): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 2 (IMXRT1170_PAD_GPIO_LPSR_02): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 3 (IMXRT1170_PAD_GPIO_LPSR_03): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 4 (IMXRT1170_PAD_GPIO_LPSR_04): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 5 (IMXRT1170_PAD_GPIO_LPSR_05): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 6 (IMXRT1170_PAD_GPIO_LPSR_06): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 7 (IMXRT1170_PAD_GPIO_LPSR_07): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 8 (IMXRT1170_PAD_GPIO_LPSR_08): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 9 (IMXRT1170_PAD_GPIO_LPSR_09): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 10 (IMXRT1170_PAD_GPIO_LPSR_10): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 11 (IMXRT1170_PAD_GPIO_LPSR_11): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 12 (IMXRT1170_PAD_GPIO_LPSR_12): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 13 (IMXRT1170_PAD_GPIO_LPSR_13): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 14 (IMXRT1170_PAD_GPIO_LPSR_14): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 15 (IMXRT1170_PAD_GPIO_LPSR_15): (MUX UNCLAIMED) (GPIO UNCLAIMED)
```
With this patch applied the iomuxc_snvs group pins showed as follows:
```
/ # cat /sys/kernel/debug/pinctrl/40c94000.iomuxc_snvs/pinmux-pins
Pinmux settings per pin
Format: pin (name): mux_owner gpio_owner hog?
pin 0 (IMXRT1170_PAD_WAKEUP_DIG): gpio-keys 40ca0000.gpio:384 function iomuxc_snvs group keysgrp
pin 1 (IMXRT1170_PAD_PMIC_ON_REQ_DIG): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 2 (IMXRT1170_PAD_PMIC_STBY_REQ_DIG): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 3 (IMXRT1170_PAD_GPIO_SNVS_00): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 4 (IMXRT1170_PAD_GPIO_SNVS_01): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 5 (IMXRT1170_PAD_GPIO_SNVS_02): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 6 (IMXRT1170_PAD_GPIO_SNVS_03): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 7 (IMXRT1170_PAD_GPIO_SNVS_04): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 8 (IMXRT1170_PAD_GPIO_SNVS_05): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 9 (IMXRT1170_PAD_GPIO_SNVS_06): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 10 (IMXRT1170_PAD_GPIO_SNVS_07): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 11 (IMXRT1170_PAD_GPIO_SNVS_08): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 12 (IMXRT1170_PAD_GPIO_SNVS_09): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 13 (IMXRT1170_PAD_TEST_MODE_DIG): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 14 (IMXRT1170_PAD_POR_B_DIG): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 15 (IMXRT1170_PAD_ONOFF_DIG): (MUX UNCLAIMED) (GPIO UNCLAIMED)
```