### PR TITLE
clk: imx: pfd: add read-modify-write mode for i.MX RT1170

### DIFF
--- a/drivers/clk/imx/clk-imxrt1170.c
+++ b/drivers/clk/imx/clk-imxrt1170.c
@@ -144,6 +144,10 @@ static struct imxrt1170_clk_ccgr clk_ccgrs[] = {
 static struct clk_hw **hws;
 static struct clk_hw_onecell_data *clk_hw_data;
 
+/* Spinlocks for PFD RMW — one per shared PFD register */
+static DEFINE_SPINLOCK(pll3_pfd_lock);
+static DEFINE_SPINLOCK(pll2_pfd_lock);
+
 /* base address of the CLOCK_GROUPn_CONTROL register */
 #define IMXRT1170_CCM_CLOCK_GROUP_CONTROL_SET(base, grp_id) (base + 0x4000 + ((grp_id) * 0x80))
 #define CGC_DIV0_SHIFT		0
@@ -196,22 +200,22 @@ static void __init imxrt1170_clocks_init(struct device_node *ccm_node)
 	       imx_clk_hw_pll_rt1170(IMXRT1170_PLL1, "pll1_sys", "osc", base + 0x2c0);
 
 	hws[IMXRT1170_CLK_PLL3_PFD0] =
-	       imx_clk_hw_pfd("pll3_pfd0", "pll3_sys", base + 0x230, 0);
+	       imx_clk_hw_pfd_rmw("pll3_pfd0", "pll3_sys", base + 0x230, 0, &pll3_pfd_lock);
 	hws[IMXRT1170_CLK_PLL3_PFD1] =
-	       imx_clk_hw_pfd("pll3_pfd1", "pll3_sys", base + 0x230, 1);
+	       imx_clk_hw_pfd_rmw("pll3_pfd1", "pll3_sys", base + 0x230, 1, &pll3_pfd_lock);
 	hws[IMXRT1170_CLK_PLL3_PFD2] =
-	       imx_clk_hw_pfd("pll3_pfd2", "pll3_sys", base + 0x230, 2);
+	       imx_clk_hw_pfd_rmw("pll3_pfd2", "pll3_sys", base + 0x230, 2, &pll3_pfd_lock);
 	hws[IMXRT1170_CLK_PLL3_PFD3] =
-	       imx_clk_hw_pfd("pll3_pfd3", "pll3_sys", base + 0x230, 3);
+	       imx_clk_hw_pfd_rmw("pll3_pfd3", "pll3_sys", base + 0x230, 3, &pll3_pfd_lock);
 
 	hws[IMXRT1170_CLK_PLL2_PFD0] =
-	       imx_clk_hw_pfd("pll2_pfd0", "pll2_sys", base + 0x270, 0);
+	       imx_clk_hw_pfd_rmw("pll2_pfd0", "pll2_sys", base + 0x270, 0, &pll2_pfd_lock);
 	hws[IMXRT1170_CLK_PLL2_PFD1] =
-	       imx_clk_hw_pfd("pll2_pfd1", "pll2_sys", base + 0x270, 1);
+	       imx_clk_hw_pfd_rmw("pll2_pfd1", "pll2_sys", base + 0x270, 1, &pll2_pfd_lock);
 	hws[IMXRT1170_CLK_PLL2_PFD2] =
-	       imx_clk_hw_pfd("pll2_pfd2", "pll2_sys", base + 0x270, 2);
+	       imx_clk_hw_pfd_rmw("pll2_pfd2", "pll2_sys", base + 0x270, 2, &pll2_pfd_lock);
 	hws[IMXRT1170_CLK_PLL2_PFD3] =
-	       imx_clk_hw_pfd("pll2_pfd3", "pll2_sys", base + 0x270, 3);
+	       imx_clk_hw_pfd_rmw("pll2_pfd3", "pll2_sys", base + 0x270, 3, &pll2_pfd_lock);
 
 	hws[IMXRT1170_CLK_PLL3_DIV2] =
 	       imxrt1170_clk_pll_div_out_composite("pll3_div2", "pll3_sys", base + 0x210, 2, 3, 0);

--- a/drivers/clk/imx/clk-pfd.c
+++ b/drivers/clk/imx/clk-pfd.c
@@ -18,15 +18,21 @@
  * @hw:		clock source
  * @reg:	PFD register address
  * @idx:	the index of PFD encoded in the register
+ * @rmw_lock:	spinlock for read-modify-write mode, or NULL for SET/CLR mode
  *
- * PFD clock found on i.MX6 series.  Each register for PFD has 4 clk_pfd
- * data encoded, and member idx is used to specify the one.  And each
- * register has SET, CLR and TOG registers at offset 0x4 0x8 and 0xc.
+ * PFD clock found on i.MX6 series and i.MX RT series.  Each register for
+ * PFD has 4 clk_pfd data encoded, and member idx is used to specify the one.
+ * On i.MX6, each register has SET, CLR and TOG registers at offset 0x4 0x8
+ * and 0xc.  On i.MX RT1170, the ANATOP module does not have SET/CLR/TOG
+ * registers, so direct read-modify-write is used instead.  In RMW mode,
+ * a shared spinlock protects against concurrent access from multiple PFDs
+ * within the same register.
  */
 struct clk_pfd {
 	struct clk_hw	hw;
 	void __iomem	*reg;
 	u8		idx;
+	spinlock_t	*rmw_lock;
 };
 
 #define to_clk_pfd(_hw) container_of(_hw, struct clk_pfd, hw)
@@ -37,10 +43,26 @@ struct clk_pfd {
 
 static void clk_pfd_do_hardware(struct clk_pfd *pfd, bool enable)
 {
-	if (enable)
-		writel_relaxed(1 << ((pfd->idx + 1) * 8 - 1), pfd->reg + CLR);
-	else
-		writel_relaxed(1 << ((pfd->idx + 1) * 8 - 1), pfd->reg + SET);
+	u32 gate_bit = 1 << ((pfd->idx + 1) * 8 - 1);
+
+	if (pfd->rmw_lock) {
+		unsigned long flags;
+		u32 val;
+
+		spin_lock_irqsave(pfd->rmw_lock, flags);
+		val = readl_relaxed(pfd->reg);
+		if (enable)
+			val &= ~gate_bit;
+		else
+			val |= gate_bit;
+		writel_relaxed(val, pfd->reg);
+		spin_unlock_irqrestore(pfd->rmw_lock, flags);
+	} else {
+		if (enable)
+			writel_relaxed(gate_bit, pfd->reg + CLR);
+		else
+			writel_relaxed(gate_bit, pfd->reg + SET);
+	}
 }
 
 static void clk_pfd_do_shared_clks(struct clk_hw *hw, bool enable)
@@ -136,8 +158,20 @@ static int clk_pfd_set_rate(struct clk_hw *hw, unsigned long rate,
 	else if (frac > 35)
 		frac = 35;
 
-	writel_relaxed(0x3f << (pfd->idx * 8), pfd->reg + CLR);
-	writel_relaxed(frac << (pfd->idx * 8), pfd->reg + SET);
+	if (pfd->rmw_lock) {
+		unsigned long flags;
+		u32 val;
+
+		spin_lock_irqsave(pfd->rmw_lock, flags);
+		val = readl_relaxed(pfd->reg);
+		val &= ~(0x3f << (pfd->idx * 8));
+		val |= frac << (pfd->idx * 8);
+		writel_relaxed(val, pfd->reg);
+		spin_unlock_irqrestore(pfd->rmw_lock, flags);
+	} else {
+		writel_relaxed(0x3f << (pfd->idx * 8), pfd->reg + CLR);
+		writel_relaxed(frac << (pfd->idx * 8), pfd->reg + SET);
+	}
 
 	return 0;
 }
@@ -164,6 +198,25 @@ static const struct clk_ops clk_pfd_ops = {
 struct clk_hw *imx_clk_hw_pfd(const char *name, const char *parent_name,
 			void __iomem *reg, u8 idx)
 {
+	return imx_clk_hw_pfd_rmw(name, parent_name, reg, idx, NULL);
+}
+EXPORT_SYMBOL_GPL(imx_clk_hw_pfd);
+
+/**
+ * imx_clk_hw_pfd_rmw - register a PFD clock using read-modify-write
+ * @name:	clock name
+ * @parent_name: parent clock name
+ * @reg:	PFD register address (shared by 4 PFDs)
+ * @idx:	PFD index within the register (0-3)
+ * @lock:	shared spinlock protecting RMW on this register
+ *
+ * For SoCs (like i.MX RT1170) where the ANATOP PFD register does not
+ * have SET/CLR/TOG companion registers.  All PFDs sharing the same
+ * register must use the same @lock to prevent concurrent RMW races.
+ */
+struct clk_hw *imx_clk_hw_pfd_rmw(const char *name, const char *parent_name,
+			void __iomem *reg, u8 idx, spinlock_t *lock)
+{
 	struct clk_pfd *pfd;
 	struct clk_hw *hw;
 	struct clk_init_data init;
@@ -175,6 +228,7 @@ struct clk_hw *imx_clk_hw_pfd(const char *name, const char *parent_name,
 
 	pfd->reg = reg;
 	pfd->idx = idx;
+	pfd->rmw_lock = lock;
 
 	init.name = name;
 	init.ops = &clk_pfd_ops;
@@ -193,4 +247,4 @@ struct clk_hw *imx_clk_hw_pfd(const char *name, const char *parent_name,
 
 	return hw;
 }
-EXPORT_SYMBOL_GPL(imx_clk_hw_pfd);
+EXPORT_SYMBOL_GPL(imx_clk_hw_pfd_rmw);

--- a/drivers/clk/imx/clk.h
+++ b/drivers/clk/imx/clk.h
@@ -336,6 +336,9 @@ struct clk_hw *imx_clk_hw_gate_exclusive(const char *name, const char *parent,
 struct clk_hw *imx_clk_hw_pfd(const char *name, const char *parent_name,
 		void __iomem *reg, u8 idx);
 
+struct clk_hw *imx_clk_hw_pfd_rmw(const char *name, const char *parent_name,
+		void __iomem *reg, u8 idx, spinlock_t *lock);
+
 struct clk_hw *imx_clk_hw_pfdv2(enum imx_pfdv2_type type, const char *name,
 	 const char *parent_name, void __iomem *reg, u8 idx);
 


### PR DESCRIPTION
The i.MX RT1170 ANATOP module does not have SET/CLR/TOG companion registers for PFD, unlike the i.MX6 series. The existing clk-pfd driver unconditionally uses SET/CLR register offsets (+0x4/+0x8), which writes to wrong registers on RT1170, making clk_set_rate() and clk_enable()/clk_disable() ineffective for PFD clocks.

Add imx_clk_hw_pfd_rmw() constructor that takes a shared spinlock and selects direct read-modify-write access instead of SET/CLR. The spinlock protects against concurrent RMW races between PFDs sharing the same register (4 PFDs per register). Use it for all PFD registrations in clk-imxrt1170.c.


Unit test:

 *  On imxrt1170-evk, add to DTS:
```
  &clks {
      assigned-clocks = <&clks IMXRT1170_CLK_PLL3_PFD3>;
      assigned-clock-rates = <270000000>;
  };
```
  * Boot and verify:
```
  cat /sys/kernel/debug/clk/pll3_pfd3/clk_rate
```
  - Without fix: rate stays at the ROM default 360000000 (PFD frac unchanged, SET/CLR writes go to wrong addresses)
  - With fix: rate reads 270000000 (frac=32, PLL3=480MHz, 480*18/32=270)

