### PR TITLE
RM-7670: arm: vfp-m: fix FPU state corruption on clone

### DIFF
--- a/arch/arm/kernel/vfp-m.c
+++ b/arch/arm/kernel/vfp-m.c
@@ -132,9 +132,8 @@ static int vfpm_notifier(struct notifier_block *self, unsigned long cmd,
 	case THREAD_NOTIFY_COPY:
 		if (current_thread->vfpstate.hard.used) {
 			vfpm_save_context(&current_thread->vfpstate);
-
+			thread->vfpstate = current_thread->vfpstate;
 			thread->vfpstate.hard.used = 1;
-			vfpm_last_thread = thread;
 		} else
 			memset(&thread->vfpstate, 0, sizeof(thread->vfpstate));
 		break;


### PR DESCRIPTION
The THREAD_NOTIFY_COPY handler incorrectly set vfpm_last_thread to the child thread after saving the parent's FPU context. Since the hardware FPU registers still belong to the parent, the next context switch would save the parent's modified FPU state into the child's vfpstate, and later restore stale pre-clone state to the parent.

Fix by keeping vfpm_last_thread pointing to the parent (hardware owner) and explicitly copying the freshly-saved FPU state to the child, which matches the upstream vfpmodule.c approach.


# Unit test:

on IMXRT1170-EVK target board use the following command to restart aktualizr in a loop:

```
n=0; while true; do n=$((n+1)); aktualizr-torizon -c /etc/sota/client.toml >/tmp/akt.log 2>&1 & pid=$!; while kill -0 $pid 2>/dev/null; do grep -q UpdateCheckComplete /tmp/akt.log && kill $pid 2>/dev/null && break; sleep 1; done; sleep 5; if grep -q Segmentation /tmp/akt.log; then echo "CRASHED on run $n"; tail -5 /tmp/akt.log; break; fi; echo "=== run $n OK ==="; sleep 1; done
```

Leave it for a few hours, then check that the loop still runs, indicating no segmentation faults.
