### PR TITLE
RM-7676: dts: imxrt1170: add SNVS RTC node

### DIFF
--- a/arch/arm/boot/dts/nxp/imx/imxrt1170.dtsi
+++ b/arch/arm/boot/dts/nxp/imx/imxrt1170.dtsi
@@ -88,6 +88,18 @@
 			fsl,mux_mask = <0x7>;
 		};
 
+		snvs: snvs@40c90000 {
+			compatible = "fsl,sec-v4.0-mon", "syscon", "simple-mfd";
+			reg = <0x40c90000 0x4000>;
+
+			snvs_rtc: snvs-rtc-lp {
+				compatible = "fsl,sec-v4.0-mon-rtc-lp";
+				regmap = <&snvs>;
+				offset = <0x34>;
+				interrupts = <66>;
+			};
+		};
+
 		lpuart1: serial@4007c000 {
 			compatible = "fsl,imxrt-lpuart", "fsl,imxrt1050-lpuart";
 			reg = <0x4007c000 0x4000>;


### PR DESCRIPTION
Add SNVS block and RTC sub-node to the i.MX RT 1170 device tree. SNVS base at 0x40C90000, RTC uses LP registers at offset 0x34, interrupt 66 (SNVS_HP_NON_TZ).

Unit test:

verify /dev/rtc0 in functional on the IMXRT1170-EVKB board:
save date to rtc then restore after reboot using hwclock

